### PR TITLE
Refactor restricted interfaces using `@spi`

### DIFF
--- a/Sources/DartSass/CompilerRequests.swift
+++ b/Sources/DartSass/CompilerRequests.swift
@@ -9,6 +9,7 @@
 import NIO
 import NIOConcurrencyHelpers
 import struct Foundation.URL
+@_spi(SassCompilerProvider) import Sass
 
 // Protocols and classes modelling compiler communication sequences
 // Debug logging, multi-message exchanges, client activity
@@ -384,7 +385,7 @@ final class CompilationRequest: ManagedCompilerRequest {
 
         switch req.identifier {
         case .functionID(let id):
-            guard let sassDynamicFunc = Sass._lookUpDynamicFunction(id: id) else {
+            guard let sassDynamicFunc = SassDynamicFunction.lookUp(id: id) else {
                 throw ProtocolError("Host function ID=\(id) not registered.")
             }
             if let asyncDynamicFunc = sassDynamicFunc as? SassAsyncDynamicFunction {

--- a/Sources/DartSass/ProtobufConversion.swift
+++ b/Sources/DartSass/ProtobufConversion.swift
@@ -9,7 +9,7 @@
 // Helpers to shuffle data in and out of the protobuf types.
 
 import struct Foundation.URL
-import Sass
+@_spi(SassCompilerProvider) import Sass
 import NIO
 
 // MARK: PB -> Native

--- a/Sources/Sass/CompilerFunction.swift
+++ b/Sources/Sass/CompilerFunction.swift
@@ -21,6 +21,7 @@ public final class SassCompilerFunction: SassValue {
 
     /// Create a new compiler function.  Unless you're implementing or mocking an interface
     /// from a Sass compiler you don't need this. :nodoc:
+    @_spi(SassCompilerProvider)
     public init(id: Int) {
         self.id = id
     }

--- a/Sources/Sass/CompilerTypes.swift
+++ b/Sources/Sass/CompilerTypes.swift
@@ -137,7 +137,7 @@ public struct Span: CustomStringConvertible {
     /// span itself doesn't cover the full lines.
     public let context: String?
 
-    /// A short human-readable description of the span. :nodoc:
+    /// A short description of the span.
     public var description: String {
         var desc = url?.lastPathComponent ?? "[input]"
         desc.append(" \(start)")

--- a/Sources/Sass/DynamicFunction.swift
+++ b/Sources/Sass/DynamicFunction.swift
@@ -56,12 +56,6 @@ private struct DynamicFunctionRuntime {
 
 private var runtime = DynamicFunctionRuntime()
 
-/// API from a compiler implementation to understand how to handle a request for a host function
-/// received from the compiler.  :nodoc:
-public func _lookUpDynamicFunction(id: UInt32) -> SassDynamicFunction? {
-    runtime.lookUp(id: id)
-}
-
 /// A dynamic Sass function.
 ///
 /// These are Sass functions, written in Swift, that are not declared up-front to the compiler when
@@ -76,6 +70,8 @@ open class SassDynamicFunction: SassValue {
     /// Create a new dynamic function.
     /// - parameter signature: The Sass function signature.
     /// - parameter function: The callback implementing the function.
+    ///
+    /// The runtime holds a reference to all created `SassDynamicFunction`s so they never reach `deinit`.
     public init(signature: SassFunctionSignature, function: @escaping SassFunction) {
         self.signature = signature
         self.function = function
@@ -112,6 +108,13 @@ open class SassDynamicFunction: SassValue {
 
     public override var description: String {
         "DynamicFunction(\(id) \(signature))"
+    }
+
+    /// API from a compiler implementation to understand how to handle a request for a host function
+    /// received from the compiler.  :nodoc:
+    @_spi(SassCompilerProvider)
+    public static func lookUp(id: UInt32) -> SassDynamicFunction? {
+        runtime.lookUp(id: id)
     }
 }
 

--- a/Tests/DartSassTests/TestFunctions.swift
+++ b/Tests/DartSassTests/TestFunctions.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 @testable import DartSass
+@_spi(SassCompilerProvider) import Sass
 
 ///
 /// Tests for custom functions.

--- a/Tests/SassTests/TestFunction.swift
+++ b/Tests/SassTests/TestFunction.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Sass
+@_spi(SassCompilerProvider) import Sass
 
 /// Compiler & dynamic functions, data-structure tests
 class TestFunction: XCTestCase {
@@ -34,7 +34,7 @@ class TestFunction: XCTestCase {
         XCTAssertEqual("f()", f1.signature)
         let f1ID = f1.id
         XCTAssertEqual("DynamicFunction(\(f1ID) f())", f1.description)
-        XCTAssertEqual(Sass._lookUpDynamicFunction(id: f1ID), f1)
+        XCTAssertEqual(SassDynamicFunction.lookUp(id: f1ID), f1)
 
         let val: SassValue = f1
         XCTAssertNoThrow(try val.asDynamicFunction())


### PR DESCRIPTION
Experiment with the early-access `@spi` feature to mark the few APIs we need from `Sass` to `DartSass` and `LibSass` but we don't want to expose to clients.