### PR TITLE
Further Swift 6 concurrency warning fixes

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,3 +1,7 @@
+New swift-protbuf release:
+* `brew upgrade swift-protobuf`
+* `make protobuf`
+
 New protocol release:
 * Update `sass` to the new tag
 * `make protobuf`

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "635b2589494c97e48c62514bc8b37ced762e0a62",
-        "version" : "2.63.0"
+        "revision" : "fc63f0cf4e55a4597407a9fc95b16a2bc44b4982",
+        "version" : "2.64.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "65e8f29b2d63c4e38e736b25c27b83e012159be8",
-        "version" : "1.25.2"
+        "revision" : "9f0c76544701845ad98716f3f6a774a892152bcb",
+        "version" : "1.26.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     dependencies: [
       .package(
         url: "https://github.com/apple/swift-protobuf.git",
-        from: "1.14.0"),
+        from: "1.26.0"),
       .package(
         url: "https://github.com/apple/swift-nio.git",
         from: "2.60.0"),

--- a/Sources/DartSass/embedded_sass.pb.swift
+++ b/Sources/DartSass/embedded_sass.pb.swift
@@ -5191,7 +5191,15 @@ extension Sass_EmbeddedProtocol_Value.Calculation.CalculationValue: SwiftProtobu
   fileprivate class _StorageClass {
     var _value: Sass_EmbeddedProtocol_Value.Calculation.CalculationValue.OneOf_Value?
 
-    static let defaultInstance = _StorageClass()
+    #if swift(>=5.10)
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+    #else
+      static let defaultInstance = _StorageClass()
+    #endif
 
     private init() {}
 
@@ -5337,7 +5345,15 @@ extension Sass_EmbeddedProtocol_Value.Calculation.CalculationOperation: SwiftPro
     var _left: Sass_EmbeddedProtocol_Value.Calculation.CalculationValue? = nil
     var _right: Sass_EmbeddedProtocol_Value.Calculation.CalculationValue? = nil
 
-    static let defaultInstance = _StorageClass()
+    #if swift(>=5.10)
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+    #else
+      static let defaultInstance = _StorageClass()
+    #endif
 
     private init() {}
 

--- a/swift-sass.xcodeproj/project.pbxproj
+++ b/swift-sass.xcodeproj/project.pbxproj
@@ -1234,6 +1234,7 @@
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE DEBUG";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
 				USE_HEADERMAP = NO;
 			};
 			name = Debug;
@@ -1259,6 +1260,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = complete;
 				USE_HEADERMAP = NO;
 			};
 			name = Release;

--- a/swift-sass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swift-sass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "635b2589494c97e48c62514bc8b37ced762e0a62",
-        "version" : "2.63.0"
+        "revision" : "fc63f0cf4e55a4597407a9fc95b16a2bc44b4982",
+        "version" : "2.64.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "65e8f29b2d63c4e38e736b25c27b83e012159be8",
-        "version" : "1.25.2"
+        "revision" : "9f0c76544701845ad98716f3f6a774a892152bcb",
+        "version" : "1.26.0"
       }
     },
     {


### PR DESCRIPTION
Resolve all concurrency warnings including new protobuf deps:
* Most fine
* Some temporary until Swift 6 (closure isolation inheritance)
* Some hacks to be resolved later