### PR TITLE
Swift 6 compiler updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     name: macOS 14 tests
     runs-on: macos-14
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.0.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d8f53ff5a636af938711c95edafa8223b444fd3db1af03d841c3ba19256cc52b",
+  "originHash" : "53d60f696b37348bd6d0930600fb6626cb305b3b74ee09a6ce93c58c690434f9",
   "pins" : [
     {
       "identity" : "semver.swift",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-        "version" : "1.1.0"
+        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
+        "version" : "1.1.1"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
-        "version" : "1.5.4"
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "fc63f0cf4e55a4597407a9fc95b16a2bc44b4982",
-        "version" : "2.64.0"
+        "revision" : "e5a216ba89deba84356bad9d4c2eab99071c745b",
+        "version" : "2.67.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "025bcb1165deab2e20d4eaba79967ce73013f496",
-        "version" : "1.2.1"
+        "revision" : "6a9e38e7bd22a3b8ba80bddf395623cf68f57807",
+        "version" : "1.3.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 
 import PackageDescription
 
@@ -14,7 +14,7 @@ let excluded = architectures.filter { $0 != arch }
 let package = Package(
     name: "swift-sass",
     platforms: [
-      .macOS("13.0"),
+      .macOS("14.0"),
     ],
     products: [
       .library(

--- a/README.md
+++ b/README.md
@@ -137,13 +137,14 @@ In recent years it has fallen behind the specification and reference
 implementations, and was
 [deprecated in 2020](https://sass-lang.com/blog/libsass-is-deprecated).
 However, work is underway to revive the project and it may be that LibSass 4
-emerges as an alternative Sass implementation with the same level of language
-support as Dart Sass.  As of spring 2023 this revival effort is on hold: I'm
-not holding my breath.
+or [libsass-ng](https://github.com/mgreter/libsass-ng/) emerges as an
+alternative Sass implementation with the same level of language support as
+Dart Sass.  As of summer 2024 this revival effort is showing signs of life but
+I'm still not holding my breath.
 
 See the experimental [libsass4 branch](https://github.com/johnfairh/swift-sass/tree/libsass4)
 for the current state of development: if LibSass itself manages to get to a
-relased V4 then this `swift-sass` package will support it as an alternative
+release then this `swift-sass` package will support it as an alternative
 integration.
 
 ## Contributions

--- a/Sources/DartSass/Compiler.swift
+++ b/Sources/DartSass/Compiler.swift
@@ -16,9 +16,6 @@ import Logging
 // CompilerChild -- Child process, NIO reads and writes
 // CompilerRequest -- job state, many, managed by CompilerWork
 
-/// XXX NIO bug?  Workaround until Swift 6? :nodoc:
-extension NIOPipeBootstrap: @unchecked Sendable {}
-
 /// A Sass compiler that uses Dart Sass as an embedded child process.
 ///
 /// The Dart Sass compiler is bundled with this package for macOS and Ubuntu 64-bit Linux.

--- a/Sources/Sass/ArgumentList.swift
+++ b/Sources/Sass/ArgumentList.swift
@@ -14,7 +14,7 @@
 ///   function.  Be careful in other scenarios: the keyword argument part of the type is excluded
 ///   from equality and listification, meaning it is easy to accidentally lose that part of the type
 ///   when passing instances through generic `SassValue` code.
-public final class SassArgumentList: SassList {
+public final class SassArgumentList: SassList, @unchecked Sendable {
     // MARK: Initializers
 
     /// Initialize a new argument list with the contents of a Swift sequence.

--- a/Sources/Sass/Calculation.swift
+++ b/Sources/Sass/Calculation.swift
@@ -17,7 +17,7 @@
 /// The API here allows you to construct `SassCalculation`s representing `calc()`-type expressions
 /// including invalid ones such as `calc(20px, 30px)` as though you were writing a stylesheet.  The
 /// validity is checked -- and the overall expression simplified -- by the compiler when it receives the value.
-public final class SassCalculation: SassValue {
+public final class SassCalculation: SassValue, @unchecked Sendable {
     // MARK: Types
 
     /// The kind of the `SassCalculation` expression

--- a/Sources/Sass/Color.swift
+++ b/Sources/Sass/Color.swift
@@ -362,7 +362,7 @@ struct ColorValue: CustomStringConvertible {
 ///
 /// - note: Parameter values follow web standards rather the Apple SDK standards,
 ///   so for example 'red' is modelled as an integer in 0...255.
-public final class SassColor: SassValue {
+public final class SassColor: SassValue, @unchecked Sendable {
     private var colorValue: ColorValue
 
     private init(_ value: ColorValue) {

--- a/Sources/Sass/CompilerFunction.swift
+++ b/Sources/Sass/CompilerFunction.swift
@@ -12,7 +12,7 @@
 ///
 /// Right now there is no way to explicitly request they be executed; all you can do with this
 /// type is validate that it appears when you expect it to and pass it back to the compiler when needed.
-public final class SassCompilerFunction: SassValue {
+public final class SassCompilerFunction: SassValue, @unchecked Sendable {
     // MARK: Properties
 
     /// The function ID.  Opaque to users, meaningful to Sass implementations.

--- a/Sources/Sass/Constants.swift
+++ b/Sources/Sass/Constants.swift
@@ -11,7 +11,7 @@
 ///
 /// You cannot create instances of this type: use `SassConstants.true` and `SassConstants.false`
 /// instead.
-public final class SassBool: SassValue {
+public final class SassBool: SassValue, @unchecked Sendable {
     // MARK: Properties
 
     /// The value of the boolean.
@@ -61,7 +61,7 @@ extension SassValue {
 /// The Sass `null` value.
 ///
 /// You cannot create instances of this type: use `SassConstants.null` instead.
-public final class SassNull: SassValue {
+public final class SassNull: SassValue, @unchecked Sendable {
     // MARK: Properties
 
     public override var isTruthy: Bool { false }

--- a/Sources/Sass/DynamicFunction.swift
+++ b/Sources/Sass/DynamicFunction.swift
@@ -60,7 +60,7 @@ private let runtime = DynamicFunctionRuntime()
 /// These are Sass functions, written in Swift, that are not declared up-front to the compiler when
 /// starting compilation.  Instead they are returned as `SassValue`s from other `SassFunction`s
 /// (that _were_ declared up-front) so the compiler can call them later on.
-public final class SassDynamicFunction: SassValue {
+public final class SassDynamicFunction: SassValue, @unchecked Sendable {
     // MARK: Initializers
 
     /// Create a new dynamic function.

--- a/Sources/Sass/List.swift
+++ b/Sources/Sass/List.swift
@@ -10,7 +10,7 @@
 /// Sass lists have a separator and may be surrounded with brackets.
 /// All Sass values can be treated as lists so much list-like behavior is available via
 /// `SassValue`.  `SassList` is mostly useful for constructing your own multi-element lists.
-public class SassList: SassValue {
+public class SassList: SassValue, @unchecked Sendable {
     // MARK: Types
     /// The list-separator character.
     public enum Separator: String, Equatable, Sendable {

--- a/Sources/Sass/Map.swift
+++ b/Sources/Sass/Map.swift
@@ -12,7 +12,7 @@
 ///
 /// When a map is viewed as a Sass list then the list is of two-element lists, one
 /// for each key-value pair in the map.  The pairs are in no particular order.
-public final class SassMap: SassValue {
+public final class SassMap: SassValue, @unchecked Sendable {
     // MARK: Initializers
 
     /// Create a `SassMap` from an existing `Dictionary`.

--- a/Sources/Sass/Mixin.swift
+++ b/Sources/Sass/Mixin.swift
@@ -8,7 +8,7 @@
 /// A Sass mixin.
 ///
 /// Values representing mixins can only be created by the compiler.  See [the Sass docs](https://sass-lang.com/documentation/values/mixins/).
-public final class SassMixin: SassValue {
+public final class SassMixin: SassValue, @unchecked Sendable {
     // MARK: Properties
 
     /// The mixin ID.  Opaque to users, meaningful to Sass implementations.

--- a/Sources/Sass/Number.swift
+++ b/Sources/Sass/Number.swift
@@ -183,7 +183,7 @@ extension Int {
 /// Because of units, `SassNumber` is not `Comparable` --- there is no ordering relation
 /// possible between "5 cm" and "12 kHz".  It is `Equatable` though respecting unit conversion
 /// so that "1 cm" == "10 mm".
-public final class SassNumber: SassValue {
+public final class SassNumber: SassValue, @unchecked Sendable {
     private let sassDouble: SassDouble
     private let units: UnitQuotient
 

--- a/Sources/Sass/String.swift
+++ b/Sources/Sass/String.swift
@@ -21,7 +21,7 @@
 ///
 /// `SassString` conforms to `Sequence` via `SassValue`.  This sequence is a singleton sequence
 /// containing the string value, not a sequence of scalars.
-public final class SassString: SassValue {
+public final class SassString: SassValue, @unchecked Sendable {
     // MARK: Initializers
 
     /// Initialize a new string.  You should quote strings unless there's a good reason not to.

--- a/Tests/SassTests/TestNumber.swift
+++ b/Tests/SassTests/TestNumber.swift
@@ -25,7 +25,7 @@ extension Sass.Unit {
     }
 }
 
-extension Ratio : Equatable {
+extension Ratio : @retroactive Equatable {
     public static func == (lhs: Ratio, rhs: Ratio) -> Bool {
         SassDouble.areEqual(lhs.apply(1), rhs.apply(1))
     }

--- a/swift-sass.xcodeproj/project.pbxproj
+++ b/swift-sass.xcodeproj/project.pbxproj
@@ -752,7 +752,6 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -762,7 +761,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -825,7 +824,6 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -834,7 +832,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -901,7 +899,6 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = DartSassEmbeddedMacOS;
@@ -909,7 +906,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -972,13 +969,12 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = DartSassEmbeddedMacOS;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1036,7 +1032,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -1087,7 +1083,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -1106,7 +1102,6 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1116,7 +1111,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGET_NAME = DartSass;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
@@ -1138,7 +1133,6 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1148,7 +1142,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGET_NAME = DartSass;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
@@ -1172,13 +1166,12 @@
 					"@loader_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGET_NAME = DartSassTests;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
@@ -1202,13 +1195,12 @@
 					"@loader_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGET_NAME = DartSassTests;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
@@ -1230,7 +1222,7 @@
 					"SWIFT_PACKAGE=1",
 					"DEBUG=1",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode -enable-experimental-feature AccessLevelOnImport";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1239,6 +1231,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE DEBUG";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
 				USE_HEADERMAP = NO;
 			};
 			name = Debug;
@@ -1256,7 +1249,7 @@
 					"$(inherited)",
 					"SWIFT_PACKAGE=1",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode -enable-experimental-feature AccessLevelOnImport";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1265,6 +1258,7 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
 				USE_HEADERMAP = NO;
 			};
 			name = Release;

--- a/swift-sass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swift-sass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-        "version" : "1.1.0"
+        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
+        "version" : "1.1.1"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
-        "version" : "1.5.4"
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "fc63f0cf4e55a4597407a9fc95b16a2bc44b4982",
-        "version" : "2.64.0"
+        "revision" : "e5a216ba89deba84356bad9d4c2eab99071c745b",
+        "version" : "2.67.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "025bcb1165deab2e20d4eaba79967ce73013f496",
-        "version" : "1.2.1"
+        "revision" : "6a9e38e7bd22a3b8ba80bddf395623cf68f57807",
+        "version" : "1.3.1"
       }
     }
   ],


### PR DESCRIPTION
Updates and more prep for Swift 6 release.

Move minimums to macOS 14, Swift 6.

A bit bodged in places, need some more considered work.

Leave Linux broken until either swift 6 releases or swiftly gets their linux vs. swift 6 thing fixed.
